### PR TITLE
Fix crash when StoreKit returns nil original transaction

### DIFF
--- a/Source/Internal/StoreKitTransactionObserver.swift
+++ b/Source/Internal/StoreKitTransactionObserver.swift
@@ -32,7 +32,8 @@ internal final class StoreKitTransactionObserver : NSObject, SKPaymentTransactio
                 case .purchasing:
                     break
                 case .restored:
-                    self.completeRestorePurchase(for: transaction, original: transaction.original ?? transaction)
+                    // In some cases, `transaction.original` can be nil. More investigation is required to determine if there is semantic value to this, or if it is a bug. For now, we use details from the main transaction only.
+                    self.completeRestorePurchase(for: transaction, original: transaction.original)
                 case .failed:
                     self.failPurchase(for: transaction)
                 case .deferred:
@@ -70,8 +71,8 @@ internal final class StoreKitTransactionObserver : NSObject, SKPaymentTransactio
         })
     }
     
-    private func completeRestorePurchase(for transaction: SKPaymentTransaction, original: SKPaymentTransaction) {
-        self.delegate?.storeKitTransactionObserver(self, didRestoreProductWith: original.payment.productIdentifier)
+    private func completeRestorePurchase(for transaction: SKPaymentTransaction, original: SKPaymentTransaction?) {
+        self.delegate?.storeKitTransactionObserver(self, didRestoreProductWith: transaction.payment.productIdentifier)
         
         SKPaymentQueue.default().finishTransaction(transaction)
     }

--- a/Source/Internal/StoreKitTransactionObserver.swift
+++ b/Source/Internal/StoreKitTransactionObserver.swift
@@ -32,7 +32,7 @@ internal final class StoreKitTransactionObserver : NSObject, SKPaymentTransactio
                 case .purchasing:
                     break
                 case .restored:
-                    self.completeRestorePurchase(for: transaction, original: transaction.original!)
+                    self.completeRestorePurchase(for: transaction, original: transaction.original ?? transaction)
                 case .failed:
                     self.failPurchase(for: transaction)
                 case .deferred:


### PR DESCRIPTION
While testing restore functionality with a sandbox user I ran into a crash where the app would persistently crash due to StoreKit returning `nil` for `transaction.original`. The crash repeats infinitely since the unfinished transaction stays in the queue and replays at next app launch. 

Nit: do we really need `original` here at all? `completeRestorePurchase` only seems to need the product ID. Is it possible for the product ID to change for a transaction? 