### PR TITLE
Move state(for: Product) functionality to purchase storage

### DIFF
--- a/Source/Merchant.swift
+++ b/Source/Merchant.swift
@@ -92,18 +92,7 @@ public final class Merchant {
     
     /// Returns the state for a `product`. Consumable products always report that they are `notPurchased`.
     public func state(for product: Product) -> PurchasedState {
-        guard let record = self.configuration.storage.record(forProductIdentifier: product.identifier) else {
-            return .notPurchased
-        }
-        
-        switch product.kind {
-            case .consumable:
-                return .notPurchased
-            case .nonConsumable, .subscription(automaticallyRenews: _):
-                let info = PurchasedProductInfo(expiryDate: record.expiryDate)
-            
-                return .isPurchased(info)
-        }
+        return self.configuration.storage.state(for: product)
     }
     
     /// Find possible purchases for the given products. If `products` is empty, then the zMerchantz finds purchases for all registered products.

--- a/Source/Persistence Storage/PurchaseStorage.swift
+++ b/Source/Persistence Storage/PurchaseStorage.swift
@@ -2,6 +2,22 @@ public protocol PurchaseStorage : AnyObject {
     func record(forProductIdentifier productIdentifier: String) -> PurchaseRecord?
     func save(_ record: PurchaseRecord) -> PurchaseStorageUpdateResult
     func removeRecord(forProductIdentifier productIdentifier: String) -> PurchaseStorageUpdateResult
+    func state(for product: Product) -> PurchasedState
+}
+
+public extension PurchaseStorage {
+  /// Returns the state for a `product`. Consumable products always report that they are `notPurchased`.
+  public func state(for product: Product) -> PurchasedState {
+    guard let record = record(forProductIdentifier: product.identifier) else { return .notPurchased }
+
+    switch product.kind {
+    case .consumable:
+      return .notPurchased
+    case .nonConsumable, .subscription(automaticallyRenews: _):
+      let info = PurchasedProductInfo(expiryDate: record.expiryDate)
+      return .isPurchased(info)
+    }
+  }
 }
 
 public enum PurchaseStorageUpdateResult {


### PR DESCRIPTION
This is a relatively simple refactoring of `state(for: Product)`. 

The goal is to enable easy checking for keychain purchase storage from an app extension where a full-blown merchant is not a viable option since StoreKit API are unavailable in an extension.

I'm using this in my app extension as follows: 
```
    guard let serviceName = Bundle.main.bundleIdentifier else {
      return
    }

    let keychain = KeychainPurchaseStorage(serviceName: serviceName)

    switch keychain.state(for: myProduct) {
    case .unknown, .notPurchased:
       // show purchase link
    case .isPurchased(_):
      // do the work
    }
```