### PR TITLE
Set Mac deployment target to 10.10 Yosemite

### DIFF
--- a/MerchantKit.xcodeproj/project.pbxproj
+++ b/MerchantKit.xcodeproj/project.pbxproj
@@ -1339,6 +1339,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"$(inherited)",
@@ -1383,6 +1384,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"$(inherited)",

--- a/Source/Internal/Extension Utilities/DateUtilities.swift
+++ b/Source/Internal/Extension Utilities/DateUtilities.swift
@@ -6,6 +6,10 @@ extension Date {
     }
     
     internal init?(fromISO8601 string: String) {
+        guard #available(OSX 10.12, *) else {
+            return nil
+        }
+        
         if let date = Date.iso8601Formatter.date(from: string) {
             self = date
         } else {
@@ -15,6 +19,7 @@ extension Date {
 }
 
 extension Date {
+    @available(OSX 10.12, *)
     private static let iso8601Formatter: ISO8601DateFormatter = {
         let dateFormatter = ISO8601DateFormatter()
         return dateFormatter

--- a/Source/Internal/Logger.swift
+++ b/Source/Internal/Logger.swift
@@ -11,6 +11,15 @@ internal class Logger {
         
     }
     
+    internal func log(message: @autoclosure () -> String, category: Category) {
+        guard #available(OSX 10.12, *) else {
+            return
+        }
+        
+        log(message: message(), category: category, type: .debug)
+    }
+    
+    @available(OSX 10.12, *)
     internal func log(message: @autoclosure () -> String, category: Category, type: OSLogType = .debug) {
         guard self.isActive else { return }
         
@@ -46,6 +55,7 @@ internal class Logger {
 }
 
 extension Logger {
+    @available(OSX 10.12, *)
     private func logStorage(for category: Category) -> OSLog {
         return OSLog(subsystem: self.loggingSubsystem, category: category.stringValue)
     }

--- a/Source/Model/Purchase.swift
+++ b/Source/Model/Purchase.swift
@@ -44,6 +44,7 @@ public struct Purchase : Hashable, CustomStringConvertible {
     
     /// Describes the terms of the subscription purchase, such as renewal period and any introductory offers. Returns nil for non-subscription purchases.
     @available(iOS 11.2, *)
+    @available(OSX 10.13.2, *)
     public var subscriptionTerms: SubscriptionTerms? {
         func subscriptionPeriod(from skSubscriptionPeriod: SKProductSubscriptionPeriod) -> SubscriptionPeriod? {
             let unitCount = skSubscriptionPeriod.numberOfUnits

--- a/Source/User Interface/ProductInterfaceController.swift
+++ b/Source/User Interface/ProductInterfaceController.swift
@@ -315,7 +315,7 @@ extension ProductInterfaceController {
                         if let purchase = purchases.purchase(for: product) {
                             let subscriptionTerms: SubscriptionTerms?
                             
-                            if #available(iOS 11.2, *) {
+                            if #available(iOS 11.2, *), #available(OSX 10.13.2, *) {
                                 subscriptionTerms = purchase.subscriptionTerms
                             } else {
                                 subscriptionTerms = nil


### PR DESCRIPTION
This sets the Mac deployment target back a few releases, and `#ifdefs` the relatively minor changes to make that happen.

Similar to what you are already doing for iOS.

The deployment target was previously unset, which I think picks your current macOS version. For me it was showing 10.14.

10.9 would require `DispatchQueue` changes, which I didn't want to touch. So it's set to 10.10.

This may be useful for other Mac developers, whose users typically have a bit slower upgrade schedule than iOS users.