### PR TITLE
Set OS X deployment target to 10.12 Sierra

### DIFF
--- a/MerchantKit.xcodeproj/project.pbxproj
+++ b/MerchantKit.xcodeproj/project.pbxproj
@@ -1339,6 +1339,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"$(inherited)",
@@ -1383,6 +1384,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"$(inherited)",

--- a/Source/Model/Purchase.swift
+++ b/Source/Model/Purchase.swift
@@ -44,6 +44,7 @@ public struct Purchase : Hashable, CustomStringConvertible {
     
     /// Describes the terms of the subscription purchase, such as renewal period and any introductory offers. Returns nil for non-subscription purchases.
     @available(iOS 11.2, *)
+    @available(OSX 10.13.2, *)
     public var subscriptionTerms: SubscriptionTerms? {
         func subscriptionPeriod(from skSubscriptionPeriod: SKProductSubscriptionPeriod) -> SubscriptionPeriod? {
             let unitCount = skSubscriptionPeriod.numberOfUnits

--- a/Source/Model/Purchase.swift
+++ b/Source/Model/Purchase.swift
@@ -43,8 +43,7 @@ public struct Purchase : Hashable, CustomStringConvertible {
     }
     
     /// Describes the terms of the subscription purchase, such as renewal period and any introductory offers. Returns nil for non-subscription purchases.
-    @available(iOS 11.2, *)
-    @available(OSX 10.13.2, *)
+    @available(iOS 11.2, macOS 10.13.2, *)
     public var subscriptionTerms: SubscriptionTerms? {
         func subscriptionPeriod(from skSubscriptionPeriod: SKProductSubscriptionPeriod) -> SubscriptionPeriod? {
             let unitCount = skSubscriptionPeriod.numberOfUnits

--- a/Source/User Interface/ProductInterfaceController.swift
+++ b/Source/User Interface/ProductInterfaceController.swift
@@ -190,6 +190,7 @@ extension ProductInterfaceController {
             }
             
             @available(iOS 11.2, *)
+            @available(OSX 10.13.2, *)
             public var subscriptionTerms: SubscriptionTerms? {
                 return self._subscriptionTerms
             }

--- a/Source/User Interface/ProductInterfaceController.swift
+++ b/Source/User Interface/ProductInterfaceController.swift
@@ -189,8 +189,7 @@ extension ProductInterfaceController {
                 self._subscriptionTerms = subscriptionTerms
             }
             
-            @available(iOS 11.2, *)
-            @available(OSX 10.13.2, *)
+            @available(iOS 11.2, macOS 10.13.2, *)
             public var subscriptionTerms: SubscriptionTerms? {
                 return self._subscriptionTerms
             }
@@ -316,7 +315,7 @@ extension ProductInterfaceController {
                         if let purchase = purchases.purchase(for: product) {
                             let subscriptionTerms: SubscriptionTerms?
                             
-                            if #available(iOS 11.2, *), #available(OSX 10.13.2, *) {
+                            if #available(iOS 11.2, macOS 10.13.2, *) {
                                 subscriptionTerms = purchase.subscriptionTerms
                             } else {
                                 subscriptionTerms = nil

--- a/Source/User Interface/ProductInterfaceController.swift
+++ b/Source/User Interface/ProductInterfaceController.swift
@@ -315,7 +315,7 @@ extension ProductInterfaceController {
                         if let purchase = purchases.purchase(for: product) {
                             let subscriptionTerms: SubscriptionTerms?
                             
-                            if #available(iOS 11.2, *) {
+                            if #available(iOS 11.2, *), #available(OSX 10.13.2, *) {
                                 subscriptionTerms = purchase.subscriptionTerms
                             } else {
                                 subscriptionTerms = nil


### PR DESCRIPTION
As discussed in #42, the 10.12 deployment target is a less intrusive change.

Only involves removing `subscriptionTerms`, which are already removed for iOS pre-11.2.