### PR TITLE
Fixed a compile time error where switch was missing a case.

### DIFF
--- a/Example/Source/PurchaseProductsViewController.swift
+++ b/Example/Source/PurchaseProductsViewController.swift
@@ -322,6 +322,8 @@ extension PurchaseProductsViewController : UITableViewDelegate {
                 return "There was an error connecting to the Internet. Check your network connectivity and try again later. (Error code: \(error.code.rawValue))"
             case .genericProblem:
                 return "There was an error loading products. Try again later."
+            case .userNotAllowedToMakePurchases:
+                return "There was an error. User is not allowed to make purchases."
         }
     }
     


### PR DESCRIPTION
Fixed a compilation error in `Example` in `PurchaseProductsViewController` where the switch in `titleForFooterInSection` over errors where missing `userNotAllowedToMakePurchases` case.