### PR TITLE
Support didRevokeEntitlementsForProductIdentifiers

### DIFF
--- a/Example/MerchantKitExample.xcodeproj/project.pbxproj
+++ b/Example/MerchantKitExample.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4359BC572177D85A003DC630 /* ProductDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4359BC562177D85A003DC630 /* ProductDatabase.swift */; };
 		4369E5612179DFA9002086C3 /* ExampleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369E5602179DFA9002086C3 /* ExampleListViewController.swift */; };
 		4369E563217A0263002086C3 /* PriceFormatterDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4369E562217A0263002086C3 /* PriceFormatterDemoViewController.swift */; };
+		5EBEA61F26541441000ADDC8 /* Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 5EBEA61E26541441000ADDC8 /* Configuration.storekit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +88,7 @@
 		4369E55E2179D9A1002086C3 /* MerchantKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MerchantKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4369E5602179DFA9002086C3 /* ExampleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleListViewController.swift; sourceTree = "<group>"; };
 		4369E562217A0263002086C3 /* PriceFormatterDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterDemoViewController.swift; sourceTree = "<group>"; };
+		5EBEA61E26541441000ADDC8 /* Configuration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Configuration.storekit; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +137,7 @@
 			isa = PBXGroup;
 			children = (
 				4359BC442177CA71003DC630 /* AppDelegate.swift */,
+				5EBEA61E26541441000ADDC8 /* Configuration.storekit */,
 				4369E5602179DFA9002086C3 /* ExampleListViewController.swift */,
 				4359BC462177CA71003DC630 /* PurchaseProductsViewController.swift */,
 				4369E562217A0263002086C3 /* PriceFormatterDemoViewController.swift */,
@@ -258,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4359BC4C2177CA72003DC630 /* Assets.xcassets in Resources */,
+				5EBEA61F26541441000ADDC8 /* Configuration.storekit in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/MerchantKitExample.xcodeproj/xcshareddata/xcschemes/MerchantKitExample.xcscheme
+++ b/Example/MerchantKitExample.xcodeproj/xcshareddata/xcschemes/MerchantKitExample.xcscheme
@@ -59,6 +59,9 @@
             ReferencedContainer = "container:MerchantKitExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../../Source/Configuration.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -54,8 +54,6 @@ extension AppDelegate : MerchantDelegate {
     // You could adjust some global interface element here, or simply do nothing, if appropriate.
     // For this example, we toggle the `UIApplication.shared.isNetworkActivityIndicatorVisible` property to show a loading indicator in the status bar.
     public func merchantDidChangeLoadingState(_ merchant: Merchant) {
-        DispatchQueue.main.async {
-            UIApplication.shared.isNetworkActivityIndicatorVisible = merchant.isLoading
-        }
+        UIApplication.shared.isNetworkActivityIndicatorVisible = merchant.isLoading
     }
 }

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -54,6 +54,8 @@ extension AppDelegate : MerchantDelegate {
     // You could adjust some global interface element here, or simply do nothing, if appropriate.
     // For this example, we toggle the `UIApplication.shared.isNetworkActivityIndicatorVisible` property to show a loading indicator in the status bar.
     public func merchantDidChangeLoadingState(_ merchant: Merchant) {
-        UIApplication.shared.isNetworkActivityIndicatorVisible = merchant.isLoading
+        DispatchQueue.main.async {
+            UIApplication.shared.isNetworkActivityIndicatorVisible = merchant.isLoading
+        }
     }
 }

--- a/Example/Source/Configuration.storekit
+++ b/Example/Source/Configuration.storekit
@@ -1,0 +1,48 @@
+{
+  "identifier" : "0A4DCE04",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "0.99",
+      "familyShareable" : false,
+      "internalID" : "A97AB5D9",
+      "localizations" : [
+        {
+          "description" : "Product One",
+          "displayName" : "Product One",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "product.one",
+      "referenceName" : "Product One",
+      "type" : "NonConsumable"
+    },
+    {
+      "displayPrice" : "0.99",
+      "familyShareable" : false,
+      "internalID" : "B7994930",
+      "localizations" : [
+        {
+          "description" : "Product Another",
+          "displayName" : "Product Another",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "product.another",
+      "referenceName" : "Product Another",
+      "type" : "NonConsumable"
+    }
+  ],
+  "settings" : {
+
+  },
+  "subscriptionGroups" : [
+
+  ],
+  "version" : {
+    "major" : 1,
+    "minor" : 1
+  }
+}

--- a/Source/Internal/StoreInterfaceDelegate.swift
+++ b/Source/Internal/StoreInterfaceDelegate.swift
@@ -10,4 +10,6 @@ internal protocol StoreInterfaceDelegate : AnyObject {
     func storeInterface(_ storeInterface: StoreInterface, didRestorePurchaseForProductWith productIdentifier: String)
     
     func storeInterface(_ storeInterface: StoreInterface, responseForStoreIntentToCommitPurchaseFrom source: Purchase.Source) -> StoreIntentResponse
+  
+    func storeInterface(_ storeInterface: StoreInterface, didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String])
 }

--- a/Source/Internal/StoreKitStoreInterface/StoreKitTransactionObserver.swift
+++ b/Source/Internal/StoreKitStoreInterface/StoreKitTransactionObserver.swift
@@ -89,4 +89,8 @@ extension StoreKitTransactionObserver : SKPaymentTransactionObserver {
 	internal func paymentQueue(_ queue: SKPaymentQueue, restoreCompletedTransactionsFailedWithError error: Swift.Error) {
         self.delegate?.storeInterface(self.storeInterface, didFinishRestoringPurchasesWith: .failure(error))
     }
+  
+  internal func paymentQueue(_ queue: SKPaymentQueue, didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String]) {
+        self.delegate?.storeInterface(self.storeInterface, didRevokeEntitlementsForProductIdentifiers: productIdentifiers)
+    }
 }

--- a/Source/Merchant.swift
+++ b/Source/Merchant.swift
@@ -505,4 +505,17 @@ extension Merchant : StoreInterfaceDelegate {
         
         return intent
     }
+  
+    internal func storeInterface(_ storeInterface: StoreInterface, didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String]) {
+        checkReceipt(updateProducts: .specific(productIdentifiers: Set(productIdentifiers)), policy: .alwaysRefresh, reason: .restorePurchases) { result in
+            switch result {
+            case .success(let products):
+                for product in products {
+                    _ = self.configuration.storage.removeRecord(forProductIdentifier: product.identifier)
+                }
+            case .failure(let error):
+                self.logger.log(message: "\(error)", category: .tasks)
+            }
+        }
+    }
 }

--- a/Source/Merchant.swift
+++ b/Source/Merchant.swift
@@ -197,7 +197,9 @@ extension Merchant {
         if updatedIsLoading != isLoading {
             self.isLoading = updatedIsLoading
             
-            self.delegate.merchantDidChangeLoadingState(self)
+            DispatchQueue.main.async {
+                self.delegate.merchantDidChangeLoadingState(self)
+            }
         }
     }
 }


### PR DESCRIPTION
In [a WWDC 20 session](https://developer.apple.com/videos/play/wwdc2020/10659/), StoreKit testing was introduced.

This PR aims to support revoking IAP.